### PR TITLE
Preserve counts matrix dims if patterns have no hits

### DIFF
--- a/tools/report.Rmd
+++ b/tools/report.Rmd
@@ -123,7 +123,7 @@ names(counts) <- targets$sampleName
 counts <- melt(counts, id.vars=c("V2", "V3", "V4"))  # patternName, VRL, VRS
 counts$L1 <- factor(counts$L1, levels=targets$sampleName) # VERY IMPORTANT! put the columns back in their original order (design matrix)
 counts <- lapply(split(counts, counts$V2), function(x) {
-  x <- dcast(x, V3 + V4 ~ L1)
+  x <- dcast(x, V3 + V4 ~ L1, fill=1, drop=FALSE)
   rownames(x) <- apply(x[, c("V3", "V4")], 1, paste, collapse="_")
   counts <- as.matrix(x[, -1:-2])
   counts <- ifelse(is.na(counts), 0, counts)


### PR DESCRIPTION
Keep matrix dimension if patterns are not found in some samples. Also, add a pseudocount to allow normalization.